### PR TITLE
expose removeAllListeners method in ValorantWebsocketClient

### DIFF
--- a/src/clients/valorant-ws/index.ts
+++ b/src/clients/valorant-ws/index.ts
@@ -133,7 +133,7 @@ export class ValorantWebsocketClient {
     this.#connection.once(event, callback);
   }
 
-  removeAllListeners(evet?: WsEvent) {
+  removeAllListeners(event?: WsEvent) {
     this.#connection.removeAllListeners(event);
   }
 

--- a/src/clients/valorant-ws/index.ts
+++ b/src/clients/valorant-ws/index.ts
@@ -133,6 +133,10 @@ export class ValorantWebsocketClient {
     this.#connection.once(event, callback);
   }
 
+  removeAllListeners(evet?: WsEvent) {
+    this.#connection.removeAllListeners(event);
+  }
+
   async call<T = any>(
     fn: ValorantWsFunction,
     opts: {


### PR DESCRIPTION
Allow websocket consumers to remove event listeners without disconnecting. 