### PR TITLE
chore: fix missing exposed files

### DIFF
--- a/.changeset/loud-seas-build.md
+++ b/.changeset/loud-seas-build.md
@@ -1,0 +1,5 @@
+---
+'@tqman/valorant-api-client': patch
+---
+
+fix missing exposed files

--- a/src/providers/auth/index.ts
+++ b/src/providers/auth/index.ts
@@ -1,2 +1,4 @@
 export * from "./auth";
+export * from "./types";
 export * from "./errors";
+export * from "./helpers";


### PR DESCRIPTION
Hi, after reviewing the source code, I noticed that some utility files and types are not being exported. At present I have applied a patch using pnpm to address this issue.
Do you have any plans for further improvements in this area?If everything looks good, could you please merge this?